### PR TITLE
config.php

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,6 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+		define('HOST', 'localhost');
+		define('USER', 'root');
+		define('PASSWORD', '');
+		define('DB_NAME', 'ethos-panel');
+?>


### PR DESCRIPTION
prevent them from viewing your configuration data config.json to config.php

http://ethos-panel.com/config/config.json
{
        "autofan": 0,
        "rigcheck": 0,
        "db_servername": "localhost",
        "db_username": "root",
        "db_password": "ef1027dxxxxxxxxxxxxxxxxxxxxxxxx",
        "db_name": "ethos-panel"
}

contents of config.php 

<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
		define('HOST', 'localhost');
		define('USER', 'root');
		define('PASSWORD', 'root');
		define('DB_NAME', 'ethos-panel');
?>